### PR TITLE
chore: rename homebrew formula to x402-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,7 +61,7 @@ changelog:
       - Merge branch
 
 brews:
-  - name: x402
+  - name: x402-cli
     repository:
       owner: port402
       name: homebrew-tap


### PR DESCRIPTION
Changes brew install command from `brew install x402` to `brew install x402-cli`. The binary command remains `x402`.